### PR TITLE
fix: restore truncated CSS/config files and fix typed-route error

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -442,4 +442,90 @@
   padding: 0.75rem 1.25rem;
   border-radius: 0.5rem;
   margin-bottom: 0.75rem;
-  border-left: 
+  border-left: 4px solid hsl(var(--primary));
+}
+
+/* Image Gallery Styles */
+.project-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+.project-gallery img {
+    border-radius: 0.75rem;
+    border: 1px solid hsl(var(--border));
+    width: 100%;
+    transition: transform 0.3s ease;
+}
+.project-gallery img:hover {
+    transform: scale(1.03);
+}
+
+/* Custom Link Buttons */
+.project-cta-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background-color: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+    padding: 0.75rem 1.5rem;
+    border-radius: 0.5rem;
+    text-decoration: none;
+    font-weight: 600;
+    transition: all 0.2s ease-in-out;
+}
+.project-cta-link:hover {
+    background-color: hsl(var(--primary) / 0.85);
+    transform: translateY(-2px);
+}
+
+/* === PROJECT PAGE STYLES END === */
+
+
+/* === NEW: Two-Column Layout Styles START === */
+
+.project-two-col-layout {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2.5rem;
+  margin-top: 2.5rem;
+}
+
+@media (min-width: 992px) {
+  .project-two-col-layout {
+    grid-template-columns: 2fr 1fr;
+  }
+}
+
+.project-feature-box {
+  background-color: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+}
+
+.project-feature-box h3 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-top: 0;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid hsl(var(--border));
+  padding-bottom: 0.75rem;
+}
+
+.project-feature-box ul {
+  list-style-type: '✓ ';
+  padding-right: 1.25rem;
+  font-size: 1rem;
+}
+
+.project-feature-box li {
+  padding-right: 0.5rem;
+  margin-bottom: 0.5rem;
+  color: hsl(var(--muted-foreground));
+}
+
+/* === Two-Column Layout Styles END === */

--- a/components/BlogGrid.tsx
+++ b/components/BlogGrid.tsx
@@ -41,7 +41,9 @@ export default function BlogGrid({ posts, initialTag = null }: BlogGridProps) {
         params.delete("tag")
       }
       // Replace so the back button doesn't cycle through every tag click.
-      router.replace(`${pathname}?${params.toString()}`, { scroll: false })
+      const url = `${pathname}?${params.toString()}`
+      // @ts-expect-error -- dynamic query string is not a static Route
+      router.replace(url, { scroll: false })
     },
     [router, pathname, searchParams],
   )

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -167,4 +167,33 @@ const config: Config = {
       keyframes: {
         "accordion-down": {
           from: { height: "0" },
-          to: { height: "var(--radix-accordion-content-height
+          to: { height: "var(--radix-accordion-content-height)" },
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: "0" },
+        },
+        "fade-up": {
+          from: { opacity: "0", transform: "translateY(8px)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
+        "underline-grow": {
+          from: { backgroundSize: "0% 1px" },
+          to: { backgroundSize: "100% 1px" },
+        },
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
+        "fade-up": "fade-up 0.6s cubic-bezier(0.22, 1, 0.36, 1) both",
+        "underline-grow": "underline-grow 0.35s ease-out forwards",
+      },
+    },
+  },
+  plugins: [
+    require("tailwindcss-animate"),
+    require("@tailwindcss/typography"),
+  ],
+}
+
+export default config


### PR DESCRIPTION
## Summary

- **`app/globals.css`** — was truncated mid-property (`border-left:` on line 445). Restored all missing project-page styles: `.project-prose-container li`, `.project-gallery`, `.project-cta-link`, `.project-two-col-layout`, and `.project-feature-box`.
- **`tailwind.config.ts`** — was truncated inside the `accordion-down` keyframe. Restored keyframes (`fade-up`, `underline-grow`), the `animation` map, `plugins` array, and the missing `export default config` statement. Without the export, Tailwind saw an empty config and couldn't resolve any utility class (root cause of the `border-border` build error).
- **`components/BlogGrid.tsx`** — added `@ts-expect-error` for `router.replace()` with a dynamic query string, which isn't assignable to the `typedRoutes` `RouteImpl` type.

## Context

A previous session silently wrote these files truncated and committed them in that state. Commit `707f2d2` restored 6 truncated TSX files but missed these two non-TSX files and the type error.

## Test plan

- [x] `npm run build` passes — 23 static pages generated, zero errors
- [ ] Verify project detail pages still render their custom styles (gallery, CTA links, feature boxes, two-column layout)
- [ ] Verify blog tag filtering works (click a tag → URL updates, grid filters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)